### PR TITLE
Add setup/install of ShellCheck

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,13 @@
 'use strict';
 
 module.exports = {
-    extends: '@swellaby/eslint-config/lib/bundles/ts-node'
+    extends: '@swellaby/eslint-config/lib/bundles/ts-node',
+    'rules': {
+        'no-unused-vars': [
+            'error',
+            {
+                argsIgnorePattern: '^_'
+            }
+        ]
+    }
 };

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -2,6 +2,7 @@
   "version": "0.1",
   "language": "en",
   "words": [
+    "armv",
     "azdo",
     "junit",
     "mocharc",
@@ -16,6 +17,7 @@
     "tagless",
     "testcontext",
     "testresults",
+    "toolrunner",
     "tslib",
     "xunit",
     "yosay"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,19 +21,15 @@
     ".vscode",
   ],
   "cSpell.enabledLanguageIds": [
-    "asciidoc",
     "azure-pipelines",
-    "html",
     "javascript",
     "json",
     "markdown",
     "plaintext",
-    "restructuredtext",
-    "scss",
+    "properties",
     "text",
     "typescript",
     "yaml",
-    "yml"
   ],
   "cSpell.dictionaries": [
     "companies",

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,14 +199,26 @@
     "@types/node": {
       "version": "11.9.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
-      "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==",
-      "dev": true
+      "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q=="
+    },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/sinon": {
       "version": "7.0.8",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.8.tgz",
       "integrity": "sha512-v8HKmpYANbS3y0cWji16uk/CV9v2CqpI+wxeW7WVZPU2E8MAcvBYbCBpeukhaWPRHbTO3tu8m6vb2IXWCbEUOQ==",
       "dev": true
+    },
+    "@types/uuid": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+      "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "acorn": {
       "version": "6.1.1",
@@ -396,6 +408,20 @@
         "q": "^1.1.2",
         "semver": "^5.1.0",
         "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
+    "azure-pipelines-tool-lib": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.11.0.tgz",
+      "integrity": "sha512-Bg3usPtOs/YvM5V9dOEwxvsructz/BTsO5mVgLQ013kJsQN9DJrTjZMAgxxdaeW1H8KPHMz/40ix1T7XZ++VCw==",
+      "requires": {
+        "@types/semver": "^5.3.0",
+        "@types/uuid": "^3.0.1",
+        "azure-pipelines-task-lib": "^2.7.1",
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "1.0.9",
         "uuid": "^3.0.1"
       }
     },
@@ -4579,8 +4605,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-      "dev": true
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -5301,8 +5326,7 @@
     "tunnel": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
-      "dev": true
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "type-check": {
       "version": "0.3.2",
@@ -5318,6 +5342,22 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
+    },
+    "typed-rest-client": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
+      "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
+      "requires": {
+        "tunnel": "0.0.4",
+        "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        }
+      }
     },
     "typescript": {
       "version": "3.3.3333",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "dependencies": {
     "azure-pipelines-task-lib": "^2.7.7",
+    "azure-pipelines-tool-lib": "^0.11.0",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"
   }

--- a/src/tasks/shellcheck/installer.ts
+++ b/src/tasks/shellcheck/installer.ts
@@ -1,1 +1,64 @@
 'use strict';
+
+import os = require('os');
+import path = require('path');
+
+import taskLib = require('azure-pipelines-task-lib');
+import toolLib = require('azure-pipelines-tool-lib');
+
+const shellCheckBinaryUrlBase = 'https://shellcheck.storage.googleapis.com';
+
+/**
+ * @private
+ */
+const installForLinux = async () => {
+    const architecture = os.arch();
+    let tarballName;
+    if (architecture === 'x64') {
+        tarballName = 'shellcheck-stable.linux.x86_64.tar.xz';
+    } else if (architecture === 'arm64') {
+        tarballName = 'shellcheck-stable.linux.armv6hf.tar.xz';
+    } else {
+        throw new Error(`Unsupported architecture ${architecture}`);
+    }
+
+    const downloadUrl = `${shellCheckBinaryUrlBase}/${tarballName}`;
+    const tarballLocation = await toolLib.downloadTool(downloadUrl);
+    const extractRoot = await toolLib.extractTar(tarballLocation);
+    toolLib.prependPath(path.join(extractRoot, 'shellcheck-stable'));
+};
+
+/**
+ * @private
+ */
+const installForMac = async () => {
+    await taskLib
+        .tool('brew')
+        .arg('install')
+        .arg('shellcheck')
+        .exec();
+};
+
+/**
+ * @private
+ */
+const installForWindows = async () => {
+    const downloadUrl = `${shellCheckBinaryUrlBase}/shellcheck-stable.exe`;
+    await toolLib.downloadTool(downloadUrl);
+};
+
+/**
+ * Installs ShellCheck
+ */
+export const installShellCheck = async () => {
+    const operatingSystem = taskLib.osType().toLowerCase();
+    if (operatingSystem === 'linux') {
+        await installForLinux();
+    } else if (operatingSystem === 'darwin') {
+        await installForMac();
+    } else if (operatingSystem === 'windows_nt') {
+        await installForWindows();
+    } else {
+        throw new Error(`Unsupported Operating System: ${operatingSystem}`);
+    }
+};

--- a/test/unit/tasks/shellcheck/installer.ts
+++ b/test/unit/tasks/shellcheck/installer.ts
@@ -1,0 +1,167 @@
+'use strict';
+
+import chai = require('chai');
+import os = require('os');
+import path = require('path');
+import Sinon = require('sinon');
+import taskLib = require('azure-pipelines-task-lib');
+import toolRunner = require('azure-pipelines-task-lib/toolrunner');
+import toolLib = require('azure-pipelines-tool-lib');
+
+import installer = require('../../../../src/tasks/shellcheck/installer');
+
+const assert = chai.assert;
+
+suite('installers', () => {
+    let taskLibOsStub: Sinon.SinonStub;
+    const shellCheckBinaryUrlBase = 'https://shellcheck.storage.googleapis.com';
+
+    setup(() => {
+        taskLibOsStub = Sinon.stub(taskLib, 'osType');
+    });
+
+    teardown(() => {
+        Sinon.restore();
+    });
+
+    test('Should throw error on unsupported operating system', async () => {
+        const operatingSystem = 'Scott-Tots';
+        taskLibOsStub.callsFake(() => operatingSystem);
+        const expErrorMessage = `Unsupported Operating System: ${operatingSystem.toLowerCase()}`;
+
+        try {
+            await installer.installShellCheck();
+            assert.isFalse(true);
+        } catch (err) {
+            assert.deepEqual(err.message, expErrorMessage);
+        }
+    });
+
+    suite('Linux installer', () => {
+        const binaryDirectoryName = 'shellcheck-stable';
+        const downloadDirectory = '/foo/bar';
+        const tempRoot = '/tmp';
+        const binaryLocation = `${tempRoot}/${binaryDirectoryName}`;
+        let osArchStub: Sinon.SinonStub;
+        let pathJoinStub: Sinon.SinonStub;
+        let toolLibDownloadStub: Sinon.SinonStub;
+        let toolLibExtractTarStub: Sinon.SinonStub;
+        let toolLibPrependPathStub: Sinon.SinonStub;
+
+        setup(() => {
+            taskLibOsStub.callsFake(() => 'linux');
+            osArchStub = Sinon.stub(os, 'arch');
+            pathJoinStub = Sinon.stub(path, 'join');
+            pathJoinStub.withArgs(tempRoot, binaryDirectoryName).callsFake(() => binaryLocation);
+            toolLibDownloadStub = Sinon.stub(toolLib, 'downloadTool').callsFake(() => Promise.resolve(downloadDirectory));
+            toolLibExtractTarStub = Sinon.stub(toolLib, 'extractTar');
+            toolLibExtractTarStub.withArgs(downloadDirectory).callsFake(() => Promise.resolve(tempRoot));
+            toolLibPrependPathStub = Sinon.stub(toolLib, 'prependPath');
+        });
+
+        test('Should throw error on unsupported architecture', async () => {
+            const architecture = 's390x';
+            osArchStub.callsFake(() => architecture);
+            const expErrorMessage = `Unsupported architecture ${architecture}`;
+            try {
+                await installer.installShellCheck();
+                assert.isFalse(true);
+            } catch (err) {
+                assert.deepEqual(err.message, expErrorMessage);
+            }
+        });
+
+        test('Should install correctly on 64-bit architecture', async () => {
+            osArchStub.callsFake(() => 'x64');
+            const expectedDownloadUrl = `${shellCheckBinaryUrlBase}/shellcheck-stable.linux.x86_64.tar.xz`;
+            await installer.installShellCheck();
+            assert.isTrue(toolLibDownloadStub.calledWithExactly(expectedDownloadUrl));
+            assert.isTrue(toolLibPrependPathStub.calledWithExactly(binaryLocation));
+        });
+
+        test('Should install correctly on arm 64-bit architecture', async () => {
+            osArchStub.callsFake(() => 'arm64');
+            const expectedDownloadUrl = `${shellCheckBinaryUrlBase}/shellcheck-stable.linux.armv6hf.tar.xz`;
+            await installer.installShellCheck();
+            assert.isTrue(toolLibDownloadStub.calledWithExactly(expectedDownloadUrl));
+            assert.isTrue(toolLibPrependPathStub.calledWithExactly(binaryLocation));
+        });
+
+        test('Should bubble errors', async () => {
+            const errMessage = 'crash';
+            osArchStub.throws(new Error(errMessage));
+            try {
+                await installer.installShellCheck();
+                assert.isFalse(true);
+            } catch (err) {
+                assert.deepEqual(err.message, errMessage);
+            }
+        });
+    });
+
+    suite('Mac installer', () => {
+        let taskLibToolStub: sinon.SinonStub;
+        let toolRunnerArgStub: sinon.SinonStub;
+        let toolRunnerExecStub: sinon.SinonStub;
+
+        const toolRunnerStub: toolRunner.ToolRunner = <toolRunner.ToolRunner> {
+            arg: (_val) => null,
+            exec: (_options) => null
+        };
+
+        setup(() => {
+            taskLibOsStub.callsFake(() => 'darwin');
+            taskLibToolStub = Sinon.stub(taskLib, 'tool').callsFake(() => toolRunnerStub);
+            toolRunnerArgStub = Sinon.stub(toolRunnerStub, 'arg').callsFake(() => toolRunnerStub);
+            toolRunnerExecStub = Sinon.stub(toolRunnerStub, 'exec');
+        });
+
+        test('Should bubble errors', async () => {
+            const errMessage = 'brew error';
+            toolRunnerExecStub.throws(new Error(errMessage));
+            try {
+                await installer.installShellCheck();
+                assert.isFalse(true);
+            } catch (err) {
+                assert.deepEqual(err.message, errMessage);
+            }
+        });
+
+        test('Should install correctly with Homebrew', async () => {
+            await installer.installShellCheck();
+            assert.isTrue(taskLibToolStub.calledOnceWithExactly('brew'));
+            assert.isTrue(toolRunnerArgStub.firstCall.calledWithExactly('install'));
+            assert.isTrue(toolRunnerArgStub.secondCall.calledWithExactly('shellcheck'));
+            assert.deepEqual(toolRunnerArgStub.callCount, 2);
+            assert.deepEqual(toolRunnerExecStub.callCount, 1);
+        });
+    });
+
+    suite('Windows installer', () => {
+        const stableExecutableFileName = 'shellcheck-stable.exe';
+        const downloadDirectory = 'c:/users/me/temp';
+        let toolLibDownloadStub: Sinon.SinonStub;
+
+        setup(() => {
+            taskLibOsStub.callsFake(() => 'Windows_NT');
+            toolLibDownloadStub = Sinon.stub(toolLib, 'downloadTool').callsFake(() => Promise.resolve(downloadDirectory));
+        });
+
+        test('Should install correctly', async () => {
+            const expectedDownloadUrl = `${shellCheckBinaryUrlBase}/${stableExecutableFileName}`;
+            await installer.installShellCheck();
+            assert.isTrue(toolLibDownloadStub.calledWithExactly(expectedDownloadUrl));
+        });
+
+        test('Should bubble errors', async () => {
+            const errMessage = 'blue screen error';
+            toolLibDownloadStub.throws(new Error(errMessage));
+            try {
+                await installer.installShellCheck();
+                assert.isFalse(true);
+            } catch (err) {
+                assert.deepEqual(err.message, errMessage);
+            }
+        });
+    });
+});

--- a/test/unit/tasks/shellcheck/task.ts
+++ b/test/unit/tasks/shellcheck/task.ts
@@ -8,7 +8,7 @@ import task = require('../../../../src/tasks/shellcheck/task');
 
 const assert = chai.assert;
 
-suite('task Tests', () => {
+suite('task', () => {
     let debugStub: Sinon.SinonStub;
     let getInputStub: Sinon.SinonStub;
     let setResultStub: Sinon.SinonStub;
@@ -26,14 +26,14 @@ suite('task Tests', () => {
         Sinon.restore();
     });
 
-    suite('input config Tests', () => {
+    suite('input config', () => {
         test('Should configure format input correctly', async () => {
             await task.run();
             assert.isTrue(getInputStub.calledWithExactly(formatInputKey, true));
         });
     });
 
-    suite('run Tests', () => {
+    suite('run', () => {
         test('Should fail task with correct error message when error is thrown', async () => {
             debugStub.throws(() => new Error());
             await task.run();


### PR DESCRIPTION
Closes #4 

Adds ability in the task to dynamically install ShellCheck for supported platform/architectures. 

In the main task, we can run a simple command (i.e. `if (taskLib.which(shellcheck)) {...}`) to determine if the `shellcheck` exists on the system, and if not, we can leverage the function added here to download/install it on the fly. 

This type of installer capability has become a common best-practice for these sorts of Azure Pipelines tasks, but it is also a necessary one in order for our task to be usable on the Hosted Pipeline Agent pools, as those do not have ShellCheck installed by default. 