### PR TITLE
Fix the binary download url for Installer task

### DIFF
--- a/src/tasks/install/installer.ts
+++ b/src/tasks/install/installer.ts
@@ -8,7 +8,7 @@ import toolRunner = require('azure-pipelines-task-lib/toolrunner');
 
 import ShellCheckVersion = require('./shellcheck-version');
 
-const shellCheckBinaryUrlBase = 'https://github.com/koalaman/shellcheck/releases/download'
+const shellCheckBinaryUrlBase = 'https://github.com/koalaman/shellcheck/releases/download';
 
 /**
  * @private
@@ -60,7 +60,8 @@ const installForWindows = async (version: string) => {
     const zipName = `shellcheck-${version}.zip`;
     const zipDownloadUrl = `${shellCheckBinaryUrlBase}/${version}/${zipName}`;
     const zipDownloadLocation = await toolLib.downloadTool(zipDownloadUrl, zipName);
-    const zipExtractionLocation = await toolLib.extractZip(zipDownloadLocation)
+    const zipExtractionLocation = await toolLib.extractZip(zipDownloadLocation);
+    taskLib.mv(`${zipExtractionLocation}/shellcheck-${version}.exe`, `${zipExtractionLocation}/shellcheck.exe`);
     toolLib.prependPath(zipExtractionLocation);
 };
 

--- a/src/tasks/install/installer.ts
+++ b/src/tasks/install/installer.ts
@@ -8,14 +8,15 @@ import toolRunner = require('azure-pipelines-task-lib/toolrunner');
 
 import ShellCheckVersion = require('./shellcheck-version');
 
-const shellCheckBinaryUrlBase = 'https://shellcheck.storage.googleapis.com';
+const shellCheckBinaryUrlBase = 'https://github.com/koalaman/shellcheck/releases/download'
 
 /**
  * @private
  */
 const installForLinux = async (version: string) => {
     const architecture = os.arch();
-    let tarballName;
+    let tarballName = '';
+    // let baseUrl = '';
     if (architecture === 'x64') {
         tarballName = `shellcheck-${version}.linux.x86_64.tar.xz`;
     } else if (architecture === 'arm64') {
@@ -24,7 +25,7 @@ const installForLinux = async (version: string) => {
         throw new Error(`Unsupported architecture ${architecture}`);
     }
 
-    const downloadUrl = `${shellCheckBinaryUrlBase}/${tarballName}`;
+    const downloadUrl = `${shellCheckBinaryUrlBase}/${version}/${tarballName}`;
     const tarballLocation = await toolLib.downloadTool(downloadUrl);
     // The ShellCheck binary tarballs are not gzip compressed. The toolLib.extractTar
     // function always adds the 'z' tar option which would always fail for ShellCheck.
@@ -56,9 +57,11 @@ const installForMac = async (version: string) => {
  * @private
  */
 const installForWindows = async (version: string) => {
-    const downloadUrl = `${shellCheckBinaryUrlBase}/shellcheck-${version}.exe`;
-    const downloadLocation = await toolLib.downloadTool(downloadUrl, 'shellcheck.exe');
-    toolLib.prependPath(path.parse(downloadLocation).dir);
+    const zipName = `shellcheck-${version}.zip`;
+    const zipDownloadUrl = `${shellCheckBinaryUrlBase}/${version}/${zipName}`;
+    const zipDownloadLocation = await toolLib.downloadTool(zipDownloadUrl, zipName);
+    const zipExtractionLocation = await toolLib.extractZip(zipDownloadLocation)
+    toolLib.prependPath(zipExtractionLocation);
 };
 
 /**

--- a/src/tasks/install/task.json
+++ b/src/tasks/install/task.json
@@ -8,8 +8,8 @@
   "helpMarkDown": "[More Information](https://github.com/swellaby/azdo-shellcheck)",
   "version": {
     "Major": 0,
-    "Minor": 1,
-    "Patch": 52
+    "Minor": 2,
+    "Patch": 0
   },
   "instanceNameFormat": "Install ShellCheck",
   "inputs": [

--- a/test/unit/tasks/install/installer.ts
+++ b/test/unit/tasks/install/installer.ts
@@ -25,7 +25,8 @@ suite('installers', () => {
         arg: (_val) => null,
         exec: (_options) => null
     };
-    const shellCheckBinaryUrlBase = 'https://shellcheck.storage.googleapis.com';
+    // const shellCheckBinaryUrlBase = 'https://shellcheck.storage.googleapis.com';
+    const shellCheckBinaryUrlBase = 'https://github.com/koalaman/shellcheck/releases/download'
 
     setup(() => {
         osTypeStub = Sinon.stub(os, 'type');
@@ -54,7 +55,7 @@ suite('installers', () => {
     });
 
     suite('Linux installer', () => {
-        const version = '0.6.0';
+        const version = 'v0.6.0';
         const binaryDirectoryName = `shellcheck-${version}`;
         const downloadDirectory = '/foo/bar';
         const tempDirectoryPath = '/vsts/work/_temp';
@@ -92,7 +93,7 @@ suite('installers', () => {
 
         test('Should install correctly on 64-bit architecture', async () => {
             osArchStub.callsFake(() => 'x64');
-            const expectedDownloadUrl = `${shellCheckBinaryUrlBase}/shellcheck-${version}.linux.x86_64.tar.xz`;
+            const expectedDownloadUrl = `${shellCheckBinaryUrlBase}/${version}/shellcheck-${version}.linux.x86_64.tar.xz`;
             await installer.installShellCheck(version);
             assert.isTrue(toolLibDownloadStub.calledWithExactly(expectedDownloadUrl));
             assert.isTrue(taskLibGetVariableStub.calledWithExactly('Agent.TempDirectory'));
@@ -105,7 +106,7 @@ suite('installers', () => {
 
         test('Should install correctly on arm 64-bit architecture', async () => {
             osArchStub.callsFake(() => 'arm64');
-            const expectedDownloadUrl = `${shellCheckBinaryUrlBase}/shellcheck-${version}.linux.armv6hf.tar.xz`;
+            const expectedDownloadUrl = `${shellCheckBinaryUrlBase}/${version}/shellcheck-${version}.linux.armv6hf.tar.xz`;
             await installer.installShellCheck(version);
             assert.isTrue(toolLibDownloadStub.calledWithExactly(expectedDownloadUrl));
             assert.isTrue(taskLibGetVariableStub.calledWithExactly('Agent.TempDirectory'));


### PR DESCRIPTION
## Changes/Notes
<!-- Add any related notes/activities included in this PR. You can delete this section if there's nothing relevant to include -->
- [x] Updates the binary download url to GitHub Releases
- [x] Change exe name on Windows to `shellcheck` (remove version specifics) since the GH Release artifact for Windows is a zip archive


## Related Issues
<!-- List any related/impacted issues. You can delete this section if there's nothing relevant to include -->
- Fixes #76
